### PR TITLE
Small dispatch fix for gamma

### DIFF
--- a/src/besselj.jl
+++ b/src/besselj.jl
@@ -348,10 +348,10 @@ In general, this is most accurate for small arguments and when nu > x.
 function besselj_power_series(v, x::T) where T
     MaxIter = 3000
     S = promote_type(T, Float64)
-    v, x = S(v), S(x)
+    x = S(x)
 
     out = zero(S)
-    a = (x/2)^v / gamma(v + one(S))
+    a = (x/2)^v / gamma(v + 1)
     t2 = (x/2)^2
     for i in 0:MaxIter
         out += a

--- a/src/besselj.jl
+++ b/src/besselj.jl
@@ -348,10 +348,10 @@ In general, this is most accurate for small arguments and when nu > x.
 function besselj_power_series(v, x::T) where T
     MaxIter = 3000
     S = promote_type(T, Float64)
-    x = S(x)
+    v, x = S(v), S(x)
 
     out = zero(S)
-    a = (x/2)^v / gamma(v + 1)
+    a = (x/2)^v / gamma(v + one(S))
     t2 = (x/2)^2
     for i in 0:MaxIter
         out += a

--- a/src/gamma.jl
+++ b/src/gamma.jl
@@ -1,5 +1,5 @@
 # Adapted from Cephes Mathematical Library (MIT license https://en.smath.com/view/CephesMathLibrary/license) by Stephen L. Moshier
-gamma(z::Number) = _gamma(float(z))
+gamma(x::Float64) = _gamma(x)
 _gamma(x::Float32) = Float32(_gamma(Float64(x)))
 
 function _gamma(x::Float64)
@@ -49,7 +49,6 @@ function _gamma(x::Float64)
     q = evalpoly(x, Q)
     return z * p / q
 end
-
 
 function gamma(n::Integer)
     n < 0 && throw(DomainError(n, "`n` must not be negative."))

--- a/src/gamma.jl
+++ b/src/gamma.jl
@@ -1,6 +1,6 @@
 # Adapted from Cephes Mathematical Library (MIT license https://en.smath.com/view/CephesMathLibrary/license) by Stephen L. Moshier
 gamma(x::Float64) = _gamma(x)
-_gamma(x::Float32) = Float32(_gamma(Float64(x)))
+gamma(x::Float32) = Float32(_gamma(Float64(x)))
 
 function _gamma(x::Float64)
     T = Float64
@@ -52,7 +52,7 @@ end
 
 function gamma(n::Integer)
     n < 0 && throw(DomainError(n, "`n` must not be negative."))
-    n == 0 && return Inf*float(n)
+    n == 0 && return Inf*one(n)
     n > 20 && return gamma(float(n))
     @inbounds return Float64(factorial(n-1))
 end

--- a/test/gamma_test.jl
+++ b/test/gamma_test.jl
@@ -3,3 +3,6 @@ x = rand(10000)*170
 @test SpecialFunctions.gamma.(BigFloat.(-x)) ≈ Bessels.gamma.(-x)
 @test isnan(Bessels.gamma(NaN))
 @test isinf(Bessels.gamma(Inf))
+
+x = [0, 1, 2, 3, 8, 15, 20, 30]
+@test SpecialFunctions.gamma.(x) ≈ Bessels.gamma.(x)


### PR DESCRIPTION
~~Unfortunately we are promoting the argument to Float64 before hitting the gamma calls....~~

```julia
# This PR
julia> @benchmark Bessels.besselj(10, x) setup=(x=rand()*0.0000000001)
BenchmarkTools.Trial: 10000 samples with 996 evaluations.
 Range (min … max):  26.144 ns … 52.565 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     27.193 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   27.259 ns ±  0.996 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

                      ▂█▅                                      
  ▂▂▂▂▂▂▂▂▂▁▁▁▁▁▁▁▁▂▂▅███▆▃▄▃▂▁▁▁▁▁▁▁▁▁▁▁▁▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▁▂ ▂
  26.1 ns         Histogram: frequency by time          29 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

# Master
julia> @benchmark Bessels.besselj(10, x) setup=(x=rand()*0.0000000001)
BenchmarkTools.Trial: 10000 samples with 988 evaluations.
 Range (min … max):  45.090 ns … 98.066 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     46.202 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   46.266 ns ±  1.262 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

                    █▂  █▂                                     
  ▂▂▂▂▂▂▂▂▁▁▂▂▂▂▂▂▄███▄███▄▃▃▂▂▂▂▂▂▂▂▂▂▂▂▁▂▁▁▁▁▁▁▁▁▁▁▂▂▂▂▂▂▂▂ ▃
  45.1 ns         Histogram: frequency by time        48.2 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```
~~So this does improve computational time now..... but I'm not for sure we should do much more than this for #58.... hoping our Float32 tests are robust enough to catch if this promotion is even needed.~~

Edit: Just fixed the dispatch calls to actually hit the gamma integer branch and fixed the proper return value at x = 0. This does nothing to improve #58 as that promotion was needed for accuracy.

