### PR TITLE
Unroll power series in complex airy functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ SIMDMath = "5443be0b-e40a-4f70-a07e-dcd652efc383"
 
 [compat]
 julia = "1.8"
-SIMDMath = "0.2.1"
+SIMDMath = "0.2.3"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/Airy/cairy.jl
+++ b/src/Airy/cairy.jl
@@ -259,8 +259,8 @@ function airyai_power_series(z::Complex{T}) where T
     z2 = z * z
     z3 = z2 * z
     p = SIMDMath.horner_simd(z3, pack_AIRYAI_POW_COEF)
-    ai = muladd(-complex(p.re[2].value, p.im[2].value), z, complex(p.re[1].value, p.im[1].value))
-    aip = muladd(complex(p.re[4].value, p.im[4].value), z2, -complex(p.re[3].value, p.im[3].value))
+    ai = muladd(-p[2], z, p[1])
+    aip = muladd(p[4], z2, -p[3])
     return ai, aip
 end
 
@@ -268,8 +268,8 @@ function airybi_power_series(z::Complex{T}) where T
     z2 = z * z
     z3 = z2 * z
     p = SIMDMath.horner_simd(z3, pack_AIRYBI_POW_COEF)
-    bi = muladd(complex(p.re[2].value, p.im[2].value), z, complex(p.re[1].value, p.im[1].value))
-    bip = muladd(complex(p.re[4].value, p.im[4].value), z2, complex(p.re[3].value, p.im[3].value))
+    bi = muladd(p[2], z, p[1])
+    bip = muladd(p[4], z2, p[3])
     return bi, bip
 end
 
@@ -368,10 +368,7 @@ end
     a = SIMDMath.fadd(pvec1, zvec)
     b = SIMDMath.fsub(pvec1, zvec)
 
-    A = complex(b.re[1].value, b.im[1].value)
-    B = complex(a.re[1].value, a.im[1].value)
-    C = complex(b.re[2].value, b.im[2].value)
-    D = complex(a.re[2].value, a.im[2].value)
+    A, B, C, D = b[1], a[1], b[2], a[2]
     return A, B, C, D
 end
 


### PR DESCRIPTION
This continues the improvement to the airy functions by speeding up the power series.

Main improvements are 1. unrolling the loop to specified terms (prevents tolerance checks and expensive `abs` in complex plane) 2. using SIMDMath for vectorizing, 3. avoiding any complex divisions.

Accuracy for these functions should be the same (the simple difference is recursion vs unrolling).

Benchmarks indicate these functions are 11-15x faster.

```julia
# latest tagged version
julia> @benchmark Bessels.airyai_power_series(z) setup=(z=rand()*8*cispi(rand()))
BenchmarkTools.Trial: 10000 samples with 987 evaluations.
 Range (min … max):   42.569 ns … 891.616 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     335.094 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   331.138 ns ± 134.109 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

        ▁ ▂ ▄ ▄▅ ▆ ▆   ▁ ▇ ▅ ▇ ▇ ▅▃ ▇ ▆ ▆ ▆ ▇ █ ▅ ▄▂ ▅ ▄ ▁       
  ▂▁▄▁▆▂█▁█▁█▂██▃█▃█▂▂▂███▂█▂█▂█▄██▅█▃█▃█▂█▂█▂█▃█▄██▅█▄█▂█▂▆▂▆▂ ▅
  42.6 ns          Histogram: frequency by time          584 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark Bessels.airybi_power_series(z) setup=(z=rand()*8*cispi(rand()))
BenchmarkTools.Trial: 10000 samples with 979 evaluations.
 Range (min … max):   41.523 ns … 605.067 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     334.922 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   326.983 ns ± 132.780 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

        ▂ ▄ ▅ ▇ ▅ ▇ ▇   ▆ █ █ ▇ ▆ ▃▂ ▇ ▅ ▇ ▇ █ ▇ ▇ █ ▆ ▇ ▄ ▁     
  ▂▂▄▁▇▁█▂█▂█▂█▂█▂█▂█▂▁▁█▃█▂█▃█▄█▅██▇█▃█▄█▃█▂█▂█▂█▂█▂█▃█▂█▂█▂▆▃ ▅
  41.5 ns          Histogram: frequency by time          569 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.


# this PR
julia> @benchmark Bessels.airyai_power_series(z) setup=(z=rand()*8*cispi(rand()))
BenchmarkTools.Trial: 10000 samples with 995 evaluations.
 Range (min … max):  28.975 ns … 45.823 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     29.270 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   29.321 ns ±  0.599 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

         █▁                                                    
  ▂▂▁▂▂▂▃██▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▂ ▂
  29 ns           Histogram: frequency by time        31.2 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark Bessels.airybi_power_series(z) setup=(z=rand()*8*cispi(rand()))
BenchmarkTools.Trial: 10000 samples with 995 evaluations.
 Range (min … max):  29.051 ns … 39.968 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     29.204 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   29.232 ns ±  0.364 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

                                      ▁▁▄▃█▅█▅█▄▄▄             
  ▂▁▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▃▃▃▅▅▇██████████████▅▆▄▄▃▃▂▂▂ ▄
  29.1 ns         Histogram: frequency by time        29.3 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```