### PR TITLE
Varargs don't specialize

### DIFF
--- a/src/misc.jl
+++ b/src/misc.jl
@@ -4,7 +4,7 @@ using Base.Math: sin_kernel, cos_kernel, sincos_kernel, rem_pio2_kernel, DoubleF
     computes sin(sum(xs)) where xs are sorted by absolute value
     Doing this is much more accurate than the naive sin(sum(xs))
 """
-function sin_sum(xs::Vararg{T})::T where T<:Base.IEEEFloat
+function sin_sum(xs::Vararg{T, N})::T where {T<:Base.IEEEFloat, N}
     n, y = rem_pio2_sum(xs...)
     n &= 3
     if n == 0
@@ -22,7 +22,7 @@ end
     computes sincos(sum(xs)) where xs are sorted by absolute value
     Doing this is much more accurate than the naive sincos(sum(xs))
 """
-function sincos_sum(xs::Vararg{T})::T where T<:Base.IEEEFloat
+function sincos_sum(xs::Vararg{T, N})::T where {T<:Base.IEEEFloat, N}
     n, y = rem_pio2_sum(xs...)
     n &= 3
     si, co = sincos_kernel(y)
@@ -37,7 +37,7 @@ function sincos_sum(xs::Vararg{T})::T where T<:Base.IEEEFloat
     end
 end
 
-function rem_pio2_sum(xs::Vararg{Float64})
+function rem_pio2_sum(xs::Vararg{Float64, N}) where N
     n = 0
     hi, lo = 0.0, 0.0
     for x in xs
@@ -65,7 +65,7 @@ function rem_pio2_sum(xs::Vararg{Float64})
     return n, DoubleFloat64(hi, lo)
 end
 
-function rem_pio2_sum(xs::Vararg{Float32})
+function rem_pio2_sum(xs::Vararg{Float32, N}) where N
     y = 0.0
     n = 0
     # The minimum cosine or sine of any Float32 that gets reduced is 1.6e-9
@@ -85,7 +85,7 @@ function rem_pio2_sum(xs::Vararg{Float32})
     return n + n_i, DoubleFloat32(y.hi)
 end
 
-function rem_pio2_sum(xs::Vararg{Float16})
+function rem_pio2_sum(xs::Vararg{Float16, N}) where N
     y = sum(Float64, xs) #Float16 can be losslessly accumulated in Float64
     n, y = rem_pio2_kernel(y)
     return n, DoubleFloat32(y.hi)


### PR DESCRIPTION
oops.
Before:
```
julia> @benchmark sin_sum(x, y, z) setup=(x=rand(); y = rand(); z = rand())
BenchmarkTools.Trial: 10000 samples with 990 evaluations.
 Range (min … max):  44.685 ns …  1.015 μs  ┊ GC (min … max): 0.00% … 92.17%
 Time  (median):     48.480 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   52.340 ns ± 35.280 ns  ┊ GC (mean ± σ):  2.69% ±  4.03%

   ▁█▅▆▅▂ ▁                                                    
  ▂████████▇▅▆▄▄▃▃▃▃▂▂▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  44.7 ns         Histogram: frequency by time        80.2 ns <

 Memory estimate: 96 bytes, allocs estimate: 5.
```
After:
```
julia> @benchmark sin_sum(x, y, z) setup=(x=rand(); y = rand(); z = rand())
BenchmarkTools.Trial: 10000 samples with 999 evaluations.
 Range (min … max):   9.629 ns … 144.460 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     11.763 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   11.850 ns ±   2.224 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

               █ ▇      ▃ ▅ ▁                                   
  ▂▁▂▂▃▂▄▃▃▄▃█▂█▂█▂█▄▃▆▂█▃█▃█▅▄▅▂▄▂▄▂▄▃▃▅▂▄▂▄▂▃▂▃▂▂▂▂▂▂▂▂▂▂▂▂▂ ▃
  9.63 ns         Histogram: frequency by time         15.4 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```