### PR TITLE
Use better sin_sum for F32

### DIFF
--- a/src/besselj.jl
+++ b/src/besselj.jl
@@ -151,8 +151,8 @@ function _besselj1(x::Float32)
         w = sqrt(q)
         p = w * evalpoly(q, MO132)
         w = q * q
-        xn = q * evalpoly(w, PH132) - THPIO4(T)
-        p = p * cos(xn + x)
+        xn = q * evalpoly(w, PH132) 
+        p = p * sin_sum(xn, -PIO4(T), x)
         return p * s
     end
 end

--- a/src/besselj.jl
+++ b/src/besselj.jl
@@ -86,7 +86,7 @@ function _besselj0(x::Float32)
         p = w * evalpoly(q, MO_j0(T))
         w = q * q
         xn = q * evalpoly(w, PH_j0(T))
-        p = p * sin_sum(xn, PIO4(Float32), x)
+        p = p * sin_sum(xn, PIO4(T), x)
         return p
     end
 end

--- a/src/besselj.jl
+++ b/src/besselj.jl
@@ -85,8 +85,8 @@ function _besselj0(x::Float32)
         w = sqrt(q)
         p = w * evalpoly(q, MO_j0(T))
         w = q * q
-        xn = q * evalpoly(w, PH_j0(T)) - PIO4(Float32)
-        p = p * cos(xn + x)
+        xn = q * evalpoly(w, PH_j0(T))
+        p = p * sin_sum(xn, PIO4(Float32), x)
         return p
     end
 end


### PR DESCRIPTION
This fixes #90 where performance was fixed in #92.

```julia
# before
julia> Bessels.besselj0(328049.34f0)
-0.0013240778f0

# after
julia> Bessels.besselj0(328049.34f0)
-0.0013258625f0

# Float64 number
julia> Bessels.besselj0(Float64(328049.34f0))
-0.001325862383187567
```

This significantly improves accuracy. The naive version of course is faster..
```julia
# Master
julia> @benchmark besselj0(x) setup=(x=Float32(rand()*100 + 20.0))
BenchmarkTools.Trial: 10000 samples with 998 evaluations.
 Range (min … max):  14.996 ns … 29.645 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     16.055 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   15.950 ns ±  0.458 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

                                               ▂      ▂█       
  ▂▂▂▂▂▂▂▂▂▂▂▂▃▄▂▂▂▃▃▂▃▃▄▃▂▁▁▁▁▁▁▁▁▁▁▁▂▂▃▃▃▃▃▃▃█▆▂▂▂▃▆██▆▃▅▇▄ ▃
  15 ns           Histogram: frequency by time        16.2 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.


# this PR
julia> @benchmark besselj0(x) setup=(x=Float32(rand()*100 + 20.0))
BenchmarkTools.Trial: 10000 samples with 997 evaluations.
 Range (min … max):  18.653 ns … 28.444 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     19.585 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   19.705 ns ±  0.369 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

                           ▆       █       ▁                   
  ▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▃▂▂▁▁▁▁▂▅█▂▁▁▁▁▁▇█▃▁▁▂▁▁▂█▄▂▁▁▁▁▁▆▆▂▂▁▁▁▁▄▇ ▃
  18.7 ns         Histogram: frequency by time        20.3 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```
So about 20% slower but performance hit is necessary here as the previous result is inaccurate.