### PR TITLE
DenseVector → AbstractVector

### DIFF
--- a/src/BesselFunctions/besseli.jl
+++ b/src/BesselFunctions/besseli.jl
@@ -451,7 +451,7 @@ function _besseli(nu::Integer, x::T) where T <: Union{Float32, Float64}
 end
 
 """
-    Bessels.besseli!(out::DenseVector{T}, ν::AbstractRange, x::T)
+    Bessels.besseli!(out::AbstractVector{T}, ν::AbstractRange, x::T)
 
 Computes the modified Bessel function, ``I_ν(x)``, of the first kind at many orders `ν` in-place using recurrence.
 The conditions `ν[1] >= 0` and `step(ν) == 1` must be met.
@@ -470,9 +470,9 @@ julia> Bessels.besseli!(out, nu, x)
 
 See also: [`besseli(ν, x)`](@ref Bessels.besseli(ν, x))
 """
-besseli!(out::DenseVector, nu::AbstractRange, x) = _besseli!(out, nu, float(x))
+besseli!(out::AbstractVector, nu::AbstractRange, x) = _besseli!(out, nu, float(x))
 
-function _besseli!(out::DenseVector{T}, nu::AbstractRange, x::T) where T
+function _besseli!(out::AbstractVector{T}, nu::AbstractRange, x::T) where T
     (nu[1] >= 0 && step(nu) == 1) || throw(ArgumentError("nu must be >= 0 with step(nu)=1"))
     len = length(out)
     !isequal(len, length(nu)) && throw(ArgumentError("out and nu must have the same length"))

--- a/src/BesselFunctions/besselj.jl
+++ b/src/BesselFunctions/besselj.jl
@@ -294,7 +294,7 @@ function _besselj(nu::Integer, x::T) where T <: Union{Float32, Float64}
 end
 
 """
-    Bessels.besselj!(out::DenseVector{T}, ν::AbstractRange, x::T)
+    Bessels.besselj!(out::AbstractVector{T}, ν::AbstractRange, x::T)
 
 Computes the Bessel function, ``j_ν(x)``, of the first kind at many orders `ν` in-place using recurrence.
 The conditions `ν[1] >= 0` and `step(ν) == 1` must be met.
@@ -313,9 +313,9 @@ julia> Bessels.besselj!(out, nu, x)
 
 See also: [`besselj(ν, x)`](@ref Bessels.besselj(ν, x))
 """
-besselj!(out::DenseVector, nu::AbstractRange, x) = _besselj!(out, nu, float(x))
+besselj!(out::AbstractVector, nu::AbstractRange, x) = _besselj!(out, nu, float(x))
 
-function _besselj!(out::DenseVector{T}, nu::AbstractVector, x::T) where T <: Union{Float32, Float64}
+function _besselj!(out::AbstractVector{T}, nu::AbstractVector, x::T) where T <: Union{Float32, Float64}
     (nu[begin] >= 0 && step(nu) == 1) || throw(ArgumentError("nu must be >= 0 with step(nu)=1"))
     len = length(out)
     !isequal(len, length(nu)) && throw(ArgumentError("out and nu must have the same length"))

--- a/src/BesselFunctions/besselk.jl
+++ b/src/BesselFunctions/besselk.jl
@@ -258,7 +258,7 @@ function _besselk(nu::Integer, x::T) where T <: Union{Float32, Float64}
 end
 
 """
-    Bessels.besselk!(out::DenseVector{T}, ν::AbstractRange, x::T)
+    Bessels.besselk!(out::AbstractVector{T}, ν::AbstractRange, x::T)
 
 Computes the modified Bessel function, ``K_ν(x)``, of the second kind at many orders `ν` in-place using recurrence.
 The conditions `ν[1] >= 0` and `step(ν) == 1` must be met.
@@ -277,9 +277,9 @@ julia> Bessels.besselk!(out, nu, x)
 
 See also: [`besselk(ν, x)`](@ref Bessels.besselk(ν, x))
 """
-besselk!(out::DenseVector, nu::AbstractRange, x) = _besselk!(out, nu, float(x))
+besselk!(out::AbstractVector, nu::AbstractRange, x) = _besselk!(out, nu, float(x))
 
-function _besselk!(out::DenseVector{T}, nu::AbstractRange, x::T) where T
+function _besselk!(out::AbstractVector{T}, nu::AbstractRange, x::T) where T
     (nu[1] >= 0 && step(nu) == 1) || throw(ArgumentError("nu must be >= 0 with step(nu)=1"))
     len = length(out)
     !isequal(len, length(nu)) && throw(ArgumentError("out and nu must have the same length"))

--- a/src/BesselFunctions/bessely.jl
+++ b/src/BesselFunctions/bessely.jl
@@ -327,7 +327,7 @@ function _bessely(nu::Integer, x::T) where T <: Union{Float32, Float64}
 end
 
 """
-    Bessels.bessely!(out::DenseVector{T}, ν::AbstractRange, x::T)
+    Bessels.bessely!(out::AbstractVector{T}, ν::AbstractRange, x::T)
 
 Computes the Bessel function, ``Y_ν(x)``, of the second kind at many orders `ν` in-place using recurrence.
 The conditions `ν[1] >= 0` and `step(ν) == 1` must be met.
@@ -346,9 +346,9 @@ julia> Bessels.bessely!(out, nu, x)
 
 See also: [`bessely(ν, x)`](@ref Bessels.bessely(ν, x))
 """
-bessely!(out::DenseVector, nu::AbstractRange, x) = _bessely!(out, nu, float(x))
+bessely!(out::AbstractVector, nu::AbstractRange, x) = _bessely!(out, nu, float(x))
 
-function _bessely!(out::DenseVector{T}, nu::AbstractRange, x::T) where T
+function _bessely!(out::AbstractVector{T}, nu::AbstractRange, x::T) where T
     (nu[begin] >= 0 && step(nu) == 1) || throw(ArgumentError("nu must be >= 0 with step(nu)=1"))
     !isequal(length(out), length(nu)) && throw(ArgumentError("out and nu must have the same length"))
     out[begin], out[begin + 1] = _bessely(nu[begin], x), _bessely(nu[begin + 1], x)


### PR DESCRIPTION
Addresses https://github.com/JuliaMath/Bessels.jl/issues/99 

Changes the type `DenseVector{T}` to `AbstractVector{T}`.