### PR TITLE
An AD compatible besselk implementation for any order or argument (real values)

### DIFF
--- a/src/BesselFunctions/besseli.jl
+++ b/src/BesselFunctions/besseli.jl
@@ -428,7 +428,7 @@ function _besseli(nu::T, x::T) where T <: Union{Float32, Float64}
         end
     else
         if x >= 0
-            return besseli_positive_args(abs_nu, abs_x) + 2 / π * sinpi(abs_nu) * besselk_positive_args(abs_nu, abs_x)
+            return besseli_positive_args(abs_nu, abs_x) + 2 / π * sinpi(abs_nu) * besselk(abs_nu, abs_x)
         else
             #Iv = besseli_positive_args(abs_nu, abs_x)
             #Kv = besselk_positive_args(abs_nu, abs_x)

--- a/src/BesselFunctions/besselk.jl
+++ b/src/BesselFunctions/besselk.jl
@@ -572,7 +572,7 @@ besselk_power_series_cutoff(nu, x::Float32) = x < 10.0f0 || nu > 1.65f0*x - 8.0f
 # whose standard forms can't be naively evaluated by a computer at the origin.
 
 # This function assumes |v|<1e-5!
-besselk_temme_series(v, x::Float32) = Float32(besselk_temme_series(v, Float64(x)))
+besselk_temme_series(v::Float32, x::Float32) = Float32(besselk_temme_series(Float64(v), Float64(x)))
 
 function besselk_temme_series(v::T, x::T) where T <: Float64
     Max_Iter = 500

--- a/src/BesselFunctions/besselk.jl
+++ b/src/BesselFunctions/besselk.jl
@@ -602,7 +602,7 @@ function besselk_temme_series(v::V, x::X) where {V , X}
 end
 
 @inline function f0_local_expansion_v0(v, x)
-    l2dx = log(2 / x)
+    l2dx = log(2) - log(x)
     mu = v * l2dx
     vv = v * v
     sp = evalpoly(vv, (1.0, 1.6449340668482264, 1.8940656589944918, 1.9711021825948702))

--- a/src/BesselFunctions/besselk.jl
+++ b/src/BesselFunctions/besselk.jl
@@ -572,7 +572,7 @@ besselk_power_series_cutoff(nu, x::Float32) = x < 10.0f0 || nu > 1.65f0*x - 8.0f
 # whose standard forms can't be naively evaluated by a computer at the origin.
 
 # This function assumes |v|<1e-5!
-besselk_temme_series(v::Float32, x::Float32) = Float32(besselk_temme_series(Float64(v), Float64(x)))
+besselk_temme_series(v::Float32, x::Float32) = Float32.(besselk_temme_series(Float64(v), Float64(x)))
 
 function besselk_temme_series(v::T, x::T) where T <: Float64
     Max_Iter = 500

--- a/src/BesselFunctions/besselk.jl
+++ b/src/BesselFunctions/besselk.jl
@@ -244,7 +244,7 @@ function _besselk(v::T, x::T) where T <: Union{Float32, Float64}
     
     else
         v_floor, v_int = modf(v)
-        if x >= 1.5 # determine cutoff as function for differnet types
+        if x > 1.5 # determine cutoff as function for differnet types
             kv, kvp1 = besselkx_levin(v_floor, x, Val(16)), besselkx_levin(v_floor + 1, x, Val(16))
             return besselk_up_recurrence(x, kvp1, kv, v_floor + 1, v)[1] * exp(-x)
         else

--- a/src/BesselFunctions/besselk.jl
+++ b/src/BesselFunctions/besselk.jl
@@ -580,26 +580,22 @@ function besselk_temme_series(v::T, x::T) where T <: Float64
     zz = z * z
     fk = f0_local_expansion_v0(v, x)
     zv = z^v
-    znv = inv(zv)
-    gam_1_c = (1.0, -0.5772156649015329, 0.9890559953279725, -0.23263776388631713)
-    gam_1pv = evalpoly(v,  gam_1_c)
-    gam_1nv = evalpoly(-v, gam_1_c)
-    (pk, qk, _ck, factk, vv) = (znv*gam_1pv/2, zv*gam_1nv/2, one(T), one(T), v*v)
-    (out_v, out_vp1) = (zero(T), zero(T))
+    pk = evalpoly(v,  (1.0, -0.5772156649015329, 0.9890559953279725, -0.23263776388631713)) / (2 * zv)
+    qk = zv * evalpoly(-v, (1.0, -0.5772156649015329, 0.9890559953279725, -0.23263776388631713)) / 2
+    ck = one(T)
+    out_v, out_vp1 = zero(T), zero(T)
 
     for k in 1:Max_Iter
-        ck = _ck / factk
         term_v = ck * fk
         term_vp1 = ck * (pk - (k-1) * fk)
         out_v += term_v
         out_vp1 += term_vp1
         ((abs(term_v) < eps(T)) && (abs(term_vp1) < eps(T))) && break
 
-        fk = (k * fk + pk + qk) / (k^2 - vv)
+        fk = (k * fk + pk + qk) / (k^2 - v^2)
         pk /= k - v
         qk /= k + v
-        _ck *= zz
-        factk *= k
+        ck *= zz / k
     end
     return out_v, out_vp1 / z
 end

--- a/test/besselk_enzyme_test.jl
+++ b/test/besselk_enzyme_test.jl
@@ -8,10 +8,10 @@ dbesselkx_dv(v, x) = autodiff(Forward, _v->besselkx_levin(_v, x, Val(30)),
 dbesselkx_dx(v, x) = autodiff(Forward, _x->besselkx_levin(v, _x, Val(30)), 
                               Duplicated, Duplicated(x, 1.0))[2]
 
-dbesselk_ps_dv(v, x) = autodiff(Forward, _v->besselk_power_series(_v, x), 
+dbesselk_ps_dv(v, x) = autodiff(Forward, _v->besselk(_v, x), 
                                 Duplicated, Duplicated(v, 1.0))[2]
 
-dbesselk_ps_dx(v, x) = autodiff(Forward, _x->besselk_power_series(v, _x), 
+dbesselk_ps_dx(v, x) = autodiff(Forward, _x->besselk(v, _x), 
                                 Duplicated, Duplicated(x, 1.0))[2]
 
 

--- a/test/besselk_test.jl
+++ b/test/besselk_test.jl
@@ -91,9 +91,9 @@ t = Float64.([besselk(m, x) for m in m, x in x])
 
 # Float 32 tests for aysmptotic expansion
 m = 20:5:200; x = 5.0f0:2.0f0:400.0f0
-t = [besselk(m, x) for m in m, x in x]
-@test t[10] isa Float32
-@test t ≈ Float32.([SpecialFunctions.besselk(m, x) for m in m, x in x])
+for m in m, x in x
+    @test Float32(besselk(m, x)) ≈ Float32(besselk(m, widen(x)))
+end
 
 # test for low values and medium orders
 m = 20:5:50; x = [1f-3, 1f-2, 1f-1, 1f0, 1.5f0, 2.0f0, 4.0f0]
@@ -165,7 +165,6 @@ end
 
 (v, x) = -14.6, -10.6
 #@test besselk(v,x) ≈ -0.0180385087581148387140033906859 - 1.54653251445680014758965158559*im
-
 
 # test besselk_levin for real and complex
 


### PR DESCRIPTION
This PR hopefully completes the `besselk` implementation to be fully AD compatible. There will of course be some things to continue to check with the derivative results but that should be fully on the AD side that we can solve those things. Perhaps the only thing will be to alter cutoffs if the derivative information is not as accurate.

Lot's of things to continue to go through. This implementation is actually more accurate and faster than the previous version for all cases except for arguments `x<1.5` and for integer orders. This is really the cost of having it be AD compatible to not rely on forward recurrence using `besselk0` and `besselk1` and have to rely on the more complicated series for these values. 

A good testing framework for this is tough.... Arb really struggles with `besselk` in general requiring a really high precision that crashes my computer each time for large arguments. The AMOS routines are pretty good so we could at least continue checking against those. Will have to work through that more.

Some benchmarks.
```julia
# this PR
julia> @benchmark Bessels.besselk(v, x) setup=(v=rand()*20; x=rand()*20)
BenchmarkTools.Trial: 10000 samples with 996 evaluations.
 Range (min … max):  21.837 ns … 134.204 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     52.585 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   72.729 ns ±  24.429 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

     ▁▁                █ ▂             ▂▁     ▁▁        ▂▅▆▄▄▄ ▂
  ▅▆▇███▇▅▃▁▁▁▁▁▁▁▁▁▁▁▁█▆█▇▇▇▇▆▅▇▆▇███▇████▆█████▅▁▁▁▁▃███████ █
  21.8 ns       Histogram: log(frequency) by time       106 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.


# master

julia> @benchmark Bessels.besselk(v, x) setup=(v=rand()*20; x=rand()*20)
BenchmarkTools.Trial: 10000 samples with 982 evaluations.
 Range (min … max):   54.990 ns … 195.010 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     120.163 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   120.468 ns ±  18.256 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

                               ▃▁▇▃▂█▆▇▅▅▅▇▅▂  ▁  ▃ ▃▃▁▂         
  ▂▂▂▂▁▂▃▂▂▁▃▄▂▂▄▃▂▃▅▃▃▄▆▃▆▄▅▆████████████████▇█▇████████▆▆▅▄▃▃ ▅
  55 ns            Histogram: frequency by time          157 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```