### PR TITLE
Small fix for previous EnzymeRules PR

### DIFF
--- a/ext/BesselsEnzymeCoreExt.jl
+++ b/ext/BesselsEnzymeCoreExt.jl
@@ -28,7 +28,7 @@ module BesselsEnzymeCoreExt
                                ::Type{Const{Bool}},
                                t::Duplicated{T},
                                s::Duplicated{T}) where{T}
-    check_convergence(t.val, s.val) && check_convergence(t.dval, s.val)
+    check_convergence(t.val, s.val) && check_convergence(t.dval, s.dval)
   end
 
   # This will be fixed upstream: see #861 for Enzyme.jl whenever the next


### PR DESCRIPTION
Many apologies, but I actually had a typo in the custom rule for `Math.check_convergence` in the case that scales the test by the series value. It is a single char difference, but I figure best to open the PR so I don't forget about the issue.