### PR TITLE
default besselh to k=1 like the docs say it does

### DIFF
--- a/src/BesselFunctions/hankel.jl
+++ b/src/BesselFunctions/hankel.jl
@@ -217,6 +217,8 @@ function besselh(nu::Real, k::Integer, x)
     end
 end
 
+besselh(nu, x) = besselh(nu, 1, x)
+
 function besselh(nu::AbstractRange, k::Integer, x::T) where T
     (nu[1] >= 0 && step(nu) == 1) || throw(ArgumentError("nu must be >= 0 with step(nu)=1"))
     if nu[end] < x

--- a/test/hankel_test.jl
+++ b/test/hankel_test.jl
@@ -31,3 +31,7 @@ v, x = 14.3, 29.4
 @test isapprox(hankelh1(0.5:1:25.5, 15.0), SpecialFunctions.hankelh1.(0.5:1:25.5, 15.0), rtol=2e-13)
 @test isapprox(hankelh1(1:50, 100.0), SpecialFunctions.hankelh1.(1:50, 100.0), rtol=2e-13)
 @test isapprox(hankelh2(1:50, 10.0), SpecialFunctions.hankelh2.(1:50, 10.0), rtol=2e-13)
+
+#test 2 arg version
+@test besselh(v, 1, x) == besselh(v, x)
+@test besselh(1:50, 1, 10.0) == besselh(1:50, 10.0)


### PR DESCRIPTION
The docs say `besselh(nu, [k=1,] x)` so if the user calls a 2 arg version of this, they are asking for `k=1`.