### PR TITLE
Support enzyme on 1.12

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         version:
           - '1'
-          - '1.9'
+          - '1.10'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ BesselsEnzymeCoreExt = "EnzymeCore"
 [compat]
 EnzymeCore = "0.8"
 SIMDMath = "0.2.5"
-julia = "1.9"
+julia = "1.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
 BesselsEnzymeCoreExt = "EnzymeCore"
 
 [compat]
-EnzymeCore = "0.7, 0.8"
+EnzymeCore = "0.8"
 SIMDMath = "0.2.5"
 julia = "1.9"
 

--- a/ext/BesselsEnzymeCoreExt.jl
+++ b/ext/BesselsEnzymeCoreExt.jl
@@ -8,46 +8,31 @@ module BesselsEnzymeCoreExt
   # A manual method that separately transforms the `val` and `dval`, because
   # sometimes the `val` can converge while the `dval` hasn't, so just using an
   # early return or something can give incorrect derivatives in edge cases.
-  function EnzymeRules.forward(func::Const{typeof(levin_transform)}, 
-                               ::Type{<:Duplicated}, 
+  function EnzymeRules.forward(config::FwdConfig,
+                               func::Const{typeof(levin_transform)},
+                               RT::Type{<:Union{Duplicated, DuplicatedNoNeed}},
                                s::Duplicated,
                                w::Duplicated)
-      (sv, dv, N) = (s.val, s.dval, length(s.val))
-      ls  = levin_transform(sv, w.val)
-      dls = levin_transform(dv, w.dval)
-      Duplicated(ls, dls)
+      ls  = levin_transform(s.val,  w.val)
+      dls = levin_transform(s.dval, w.dval)
+      RT <: DuplicatedNoNeed ? dls : Duplicated(ls, dls)
   end
 
-  function EnzymeRules.forward(func::Const{typeof(check_convergence)},
-                               ::Type{Const{Bool}},
+  # Series in `besseli`/`besselk` converge faster on the value than on the
+  # dual; insist that *both* be converged before short-circuiting.
+  function EnzymeRules.forward(config::FwdConfig,
+                               func::Const{typeof(check_convergence)},
+                               ::Type{<:Const},
                                t::Duplicated{T}) where{T}
     check_convergence(t.val) && check_convergence(t.dval)
   end
 
-  function EnzymeRules.forward(func::Const{typeof(check_convergence)},
-                               ::Type{Const{Bool}},
+  function EnzymeRules.forward(config::FwdConfig,
+                               func::Const{typeof(check_convergence)},
+                               ::Type{<:Const},
                                t::Duplicated{T},
                                s::Duplicated{T}) where{T}
     check_convergence(t.val, s.val) && check_convergence(t.dval, s.dval)
   end
-
-  # This will be fixed upstream: see #861 for Enzyme.jl whenever the next
-  # release occurs.
-  function EnzymeRules.forward(func::Const{typeof(sinpi)}, 
-                               ::Type{<:Duplicated}, 
-                               x::Duplicated)
-      (sp, cp) = sincospi(x.val)
-      Duplicated(sp, pi*cp*x.dval)
-  end
-
-  # #861 will probably also mean this can be deleted at the next release of
-  # Enzyme.jl.
-  function EnzymeRules.forward(func::Const{typeof(sinpi)}, 
-                               ::Type{<:Const}, 
-                               x::Const)
-      sinpi(x.val)
-  end
-
-
 
 end

--- a/test/besseli_enzyme_test.jl
+++ b/test/besseli_enzyme_test.jl
@@ -1,10 +1,10 @@
 using EnzymeCore, Enzyme
 
-dbesseli_dv(v, x) = autodiff(Forward, _v->besseli(_v, x), 
-                             Duplicated, Duplicated(v, 1.0))[2]
+dbesseli_dv(v, x) = only(autodiff(Forward, _v->besseli(_v, x),
+                                  Duplicated, Duplicated(v, 1.0)))
 
-dbesseli_dx(v, x) = autodiff(Forward, _x->besseli(v, _x), 
-                             Duplicated, Duplicated(x, 1.0))[2]
+dbesseli_dx(v, x) = only(autodiff(Forward, _x->besseli(v, _x),
+                                  Duplicated, Duplicated(x, 1.0)))
 
 
 for line in eachline("data/besseli/enzyme/besseli_enzyme_tests.csv")

--- a/test/besselk_enzyme_test.jl
+++ b/test/besselk_enzyme_test.jl
@@ -2,28 +2,33 @@ using EnzymeCore, Enzyme
 import Bessels.BesselFunctions: besselkx_levin
 import Bessels.BesselFunctions: besselk_power_series
 
-dbesselkx_dv(v, x) = autodiff(Forward, _v->besselkx_levin(_v, x, Val(30)), 
-                              Duplicated, Duplicated(v, 1.0))[2]
+dbesselkx_dv(v, x) = only(autodiff(Forward, _v->besselkx_levin(_v, x, Val(30)),
+                              Duplicated, Duplicated(v, 1.0)))
 
-dbesselkx_dx(v, x) = autodiff(Forward, _x->besselkx_levin(v, _x, Val(30)), 
-                              Duplicated, Duplicated(x, 1.0))[2]
+dbesselkx_dx(v, x) = only(autodiff(Forward, _x->besselkx_levin(v, _x, Val(30)),
+                              Duplicated, Duplicated(x, 1.0)))
 
-dbesselk_ps_dv(v, x) = autodiff(Forward, _v->besselk(_v, x), 
-                                Duplicated, Duplicated(v, 1.0))[2]
+dbesselk_ps_dv(v, x) = only(autodiff(Forward, _v->besselk(_v, x),
+                                Duplicated, Duplicated(v, 1.0)))
 
-dbesselk_ps_dx(v, x) = autodiff(Forward, _x->besselk(v, _x), 
-                                Duplicated, Duplicated(x, 1.0))[2]
+dbesselk_ps_dx(v, x) = only(autodiff(Forward, _x->besselk(v, _x),
+                                Duplicated, Duplicated(x, 1.0)))
 
 
+@testset "Besselkx autodiff" begin
 for line in eachline("data/besselk/enzyme/besselkx_levin_enzyme_tests.csv")
+    local v, x
     (v, x, dv, dx) = parse.(Float64, split(line))
     test_dv = dbesselkx_dv(v, x)
     test_dx = dbesselkx_dx(v, x)
     @test isapprox(dv, test_dv, rtol=5e-14)
     @test isapprox(dx, test_dx, rtol=5e-14)
 end
+end
 
+@testset "Besselk autodiff" begin
 for line in eachline("data/besselk/enzyme/besselk_power_series_enzyme_tests.csv")
+    local v, x
     (v, x, dv, dx) = parse.(Float64, split(line))
     test_dv   = dbesselk_ps_dv(v, x)
     test_dx   = dbesselk_ps_dx(v, x)
@@ -35,4 +40,4 @@ for line in eachline("data/besselk/enzyme/besselk_power_series_enzyme_tests.csv"
         @test isapprox(dx, test_dx, rtol=5e-14)
     end
 end
-
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,11 +10,5 @@ import SpecialFunctions
 @time @testset "gamma" begin include("gamma_test.jl") end
 @time @testset "airy" begin include("airy_test.jl") end
 @time @testset "sphericalbessel" begin include("sphericalbessel_test.jl") end
-
-# https://github.com/EnzymeAD/Enzyme.jl/issues/2699
-if VERSION > v"1.12"
-    @warn "Skipping enzyme autodiff tests on Julia > 1.12 due to Enzyme.jl compatibility issues."
-else
-    @time @testset "besselk enzyme autodiff" begin include("besselk_enzyme_test.jl") end
-    @time @testset "besseli enzyme autodiff" begin include("besseli_enzyme_test.jl") end
-end
+@time @testset "besselk enzyme autodiff" begin include("besselk_enzyme_test.jl") end
+@time @testset "besseli enzyme autodiff" begin include("besseli_enzyme_test.jl") end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,5 +10,9 @@ import SpecialFunctions
 @time @testset "gamma" begin include("gamma_test.jl") end
 @time @testset "airy" begin include("airy_test.jl") end
 @time @testset "sphericalbessel" begin include("sphericalbessel_test.jl") end
-@time @testset "besselk enzyme autodiff" begin include("besselk_enzyme_test.jl") end
-@time @testset "besseli enzyme autodiff" begin include("besseli_enzyme_test.jl") end
+if VERSION > v"1.14-"
+    @warn "Skipping enzyme autodiff tests on Julia >= 1.14 due to Enzyme.jl compatibility issues."
+else
+    @time @testset "besselk enzyme autodiff" begin include("besselk_enzyme_test.jl") end
+    @time @testset "besseli enzyme autodiff" begin include("besseli_enzyme_test.jl") end
+end


### PR DESCRIPTION
Enzyme now works on 1.12. OTOH, some of the Enzyme tests are failing numerically. @heltonmc how were the references generated?